### PR TITLE
Add password confirmation modal and check-password endpoint

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -113,13 +113,30 @@ def login():
     response_body['message'] = "Method not allowed."
     return response_body, 405
 
+@api.route("/check-password", methods=["POST"])
+@jwt_required()
+def check_password():
+    response_body = {}
+    current_user = get_jwt_identity()
+    if request.method == 'POST':
+        password = request.json.get("password", None)
+        user = db.session.execute(db.select(Users).filter(Users.username.ilike(current_user['username']))).scalar()
+        if bcrypt.checkpw(password.encode('utf-8'), user.password.encode('utf-8')):
+            response_body["message"] = f"Password is correct"
+            response_body["results"] = {'correct':True}
+            return response_body, 200
+        response_body["message"] = "Incorrect password."
+        response_body["results"] = {'correct':False}
+        return response_body, 200
+    response_body['message'] = "Method not allowed."
+    return response_body, 405
+
 @api.route("/check-current-user", methods=["GET"])
 @jwt_required()
 def check_current_user():
     response_body = {}
     current_user = get_jwt_identity()
     if request.method == 'GET':
-        print(current_user)
         response_body['message'] = f"El usuario es: {current_user['username']}"
         response_body['results'] = current_user
         return response_body, 200
@@ -639,7 +656,7 @@ def handle_user_settings(user_id, setting_name):
         if not (current_user['id'] == user_id) and not (current_user['role'] == 'admin'):
             response_body['message'] = f"You have no permissions to do that!"
             return response_body, 401
-        setting = db.session.execute(db.select(User_settings).filter(User_settings.setting_name.ilike(setting_name))).scalar()
+        setting = db.session.execute(db.select(User_settings).filter(User_settings.user_id == user_id, User_settings.setting_name.ilike(setting_name))).scalar()
         if not setting:
             response_body['message'] = f"Setting doesn't exists, cannot edit"
             return response_body, 400
@@ -654,9 +671,10 @@ def handle_user_settings(user_id, setting_name):
         for key, value in data.items():
             if hasattr(setting, key) and allowed_attributes.get(key, False):
                 setattr(setting, key, value)
+        print(setting.serialize())
         db.session.commit()
         response_body['message'] = "Setting updated"
-        return response_body, 405
+        return response_body, 200
     response_body['message'] = "Method not allowed."
     return response_body, 405
 

--- a/src/front/js/component/ModalConfirmPassword.jsx
+++ b/src/front/js/component/ModalConfirmPassword.jsx
@@ -1,0 +1,40 @@
+import React, { useContext, useState } from "react";
+import { Context } from "../store/appContext";
+import { Modal, Form } from "react-bootstrap";
+
+export const ModalConfirmPassword = ({ show = false, handleClose, onPasswordConfirmed }) => {
+    
+    const { actions } = useContext(Context);
+    const [currentPassword, setCurrentPassword] = useState('')
+
+    const handleCheckPassword = async (event) => {
+        event.preventDefault();
+        const checkCurrentPassword = await actions.checkPassword({'password': currentPassword})
+        if (checkCurrentPassword.results.correct == false){
+            alert('Current password is incorrect!')
+        } else {
+            onPasswordConfirmed(true)
+            handleClose()
+        }
+    }
+
+    return (
+        <Modal show={show} onHide={handleClose} centered>
+            <Modal.Header closeButton>
+                <Modal.Title>Please confirm your password</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Form.Group className="my-3" controlId="formBasicPassword">
+                        <Form.Label>Current Password</Form.Label>
+                        <Form.Control type="password" placeholder="Password" name='password' value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} required />
+                    </Form.Group>
+                </Form>
+            </Modal.Body>
+            <Modal.Footer>
+                <button type="button" className="btn btn-secondary" onClick={() => {onPasswordConfirmed(false), setCurrentPassword(''), handleClose()}}>Cancel</button>
+                <button type="button" className="btn btn-primary" onClick={handleCheckPassword}>Confirm Password</button>
+            </Modal.Footer>
+        </Modal>
+    )
+}

--- a/src/front/js/component/ModalPassword.jsx
+++ b/src/front/js/component/ModalPassword.jsx
@@ -1,0 +1,79 @@
+import React, { useContext, useState } from "react";
+import { Context } from "../store/appContext";
+import { Modal, Form } from "react-bootstrap";
+import { ModalConfirmPassword } from './ModalConfirmPassword.jsx';
+import { useNavigate } from "react-router-dom";
+
+
+export const ModalPassword = ({ username, show = false, handleClose }) => {
+    const { actions } = useContext(Context);
+    const [isPasswordCorrect, setIsPasswordCorrect] = useState(false);
+    const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+    const [confirmPassword, setConfirmPassword] = useState('')
+    const [newPassword, setNewPassword] = useState('')
+    const navigate = useNavigate()
+
+    const handleOpenConfirm = () => {
+        setShowPasswordConfirm(true)
+    }
+
+    const handleCloseConfirm = () => {
+        setShowPasswordConfirm(false)
+    }
+
+    const handlePasswordConfirmation = (isCorrect) => {
+        setIsPasswordCorrect(isCorrect);
+    }
+
+    const handleSavePassword = async (event) => {
+        event.preventDefault();
+        if (confirmPassword !== newPassword){
+            return alert("Passwords doesn't match")
+        }
+
+        if (!isPasswordCorrect) {
+            return handleOpenConfirm();
+        }
+
+        const confirmUpdate = window.confirm("You will be logged out to update your user profile.")
+        if (confirmUpdate) {
+            const response = await actions.editUser(username, { "password": newPassword })
+            setConfirmPassword('')
+            alert(response.message)
+            actions.signedOut()
+            navigate('/')
+        }
+
+        handleCloseConfirm();
+    }
+
+    return (
+        <>
+            <Modal show={show} onHide={handleClose} centered>
+                <Modal.Header closeButton>
+                    <Modal.Title>Edit Password</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <Form>
+                        <Form.Group className="my-3" controlId="formBasicPassword">
+                            <Form.Label>Password</Form.Label>
+                            <Form.Control type="password" placeholder="Password" name='password' value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
+                        </Form.Group>
+
+                        <Form.Group className="my-3" controlId="formBasicConfirmPassword">
+                            <Form.Label>Confirm Password</Form.Label>
+                            <Form.Control type="password" placeholder="Confirm Password" name='confirmPassword' value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
+                        </Form.Group>
+
+                    </Form>
+                </Modal.Body>
+                <Modal.Footer>
+                    <button type="button" className="btn btn-secondary" onClick={handleClose}>Close</button>
+                    <button type="button" className="btn btn-primary" onClick={handleSavePassword}>Save changes</button>
+                </Modal.Footer>
+            </Modal>
+            <ModalConfirmPassword show={showPasswordConfirm} handleClose={handleCloseConfirm} onPasswordConfirmed={handlePasswordConfirmation} />
+
+        </>
+    )
+}

--- a/src/front/js/component/Settings.jsx
+++ b/src/front/js/component/Settings.jsx
@@ -2,12 +2,11 @@ import React, { useContext, useEffect, useState } from "react";
 import { Navigate, useParams, useNavigate } from "react-router-dom";
 import { Context } from "../store/appContext";
 import { Modal, Button, Form } from "react-bootstrap";
+import { ModalPassword } from "./ModalPassword.jsx";
 
-export const Settings = ({ show, handleClose }) => {
+export const Settings = ({ show = false, handleClose }) => {
 
     const { actions, store } = useContext(Context);
-    const [confirmPassword, setConfirmPassword] = useState('')
-    const [newPassword, setNewPassword] = useState("")
     const [showPasswordEdit, setShowPasswordEdit] = useState(false);
     const [privacy, setPrivacy] = useState(false);
     const [infoProfile, setInfoProfile] = useState({
@@ -26,20 +25,6 @@ export const Settings = ({ show, handleClose }) => {
     });
     const params = useParams();
     const navigate = useNavigate()
-
-
-    const handleSavePassword = async (event) => {
-        event.preventDefault();
-        const confirmUpdate = window.confirm("You will be logged out to update your user profile.")
-        if ((confirmPassword === newPassword) && (confirmUpdate)) {
-            const response = await actions.editUser(infoProfile.username, {"password": newPassword})
-            setConfirmPassword('')
-            alert(response.message)
-            window.location.reload(true)
-        } else {
-            alert("Passwords doesn't match")
-        }
-    }
 
     const handleOpenPassword = () => {
         setShowPasswordEdit(true)
@@ -63,8 +48,9 @@ export const Settings = ({ show, handleClose }) => {
         try {
             const confirmUpdate = window.confirm("You will be logged out to update your user profile.")
             if (confirmUpdate) {
-                const response = await actions.editUser(infoProfile.username, editProfile);
-                await actions.editSetting(infoProfile.id, "privacy", { "setting_value": privacy })
+                const response = await actions.editUser(params.username, editProfile);
+                const privacyBool = privacy == true ? "private" : "public"
+                await actions.editSetting(infoProfile.id, "privacy", { "setting_value": privacyBool })
                 alert(response.message)
                 actions.signedOut()
                 navigate("/")
@@ -85,11 +71,10 @@ export const Settings = ({ show, handleClose }) => {
     }
     const getProfile = async () => {
         const response = await actions.getUser(params.username)
-        setInfoProfile(response.results)
-        console.log(privacy)
         const privacySetting = response.results.settings.find(obj => obj.setting_name == 'privacy');
+        console.log(privacySetting)
+        setInfoProfile(response.results)
         setPrivacy(privacySetting.setting_value == 'private' ? true : false)
-        console.log(response.results);
     }
 
     useEffect(() => {
@@ -133,7 +118,7 @@ export const Settings = ({ show, handleClose }) => {
                                 <div className="accordion-body">
                                     <div className="form-floating">
                                         <input type="email" className="form-control" id="floatingInput" placeholder="name@example.com" value={infoProfile.email} onChange={handleInputChange} name="email" />
-                                        <label for="floatingInput">E-mail</label>
+                                        <label htmlFor="floatingInput">E-mail</label>
                                     </div>
                                     <div className="form-floating my-3 mx-3 ">
                                         <button type="btn" className="btn btn-sm btn-danger" onClick={handleOpenPassword}>
@@ -143,7 +128,7 @@ export const Settings = ({ show, handleClose }) => {
 
                                     <div className="form-check form-switch mt-3">
                                         <input className="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault" checked={privacy} onChange={() => setPrivacy(!privacy)} />
-                                        <label className="form-check-label" for="flexSwitchCheckDefault">Credits Private</label>
+                                        <label className="form-check-label" htmlFor="flexSwitchCheckDefault">Credits Private</label>
                                     </div>
                                 </div>
                             </div>
@@ -169,37 +154,12 @@ export const Settings = ({ show, handleClose }) => {
                         </div>
                     </div>
                 </Modal.Body>
-                <Modal.Footer onSubmit={handleEditProfile}>
+                <Modal.Footer>
                     <button type="button" className="btn btn-secondary" onClick={handleClose}>Close</button>
                     <button type="button" className="btn btn-primary" onClick={handleEditProfile}>Save changes</button>
                 </Modal.Footer>
             </Modal>
-
-            {/* Modal de la Password */}
-
-            <Modal show={showPasswordEdit} onHide={handleClosePassword} centered>
-                <Modal.Header closeButton>
-                    <Modal.Title>Edit Password</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    <Form>
-                        <Form.Group className="my-3" controlId="formBasicPassword">
-                            <Form.Label>Password *</Form.Label>
-                            <Form.Control type="password" placeholder="Password" name='password' value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
-                        </Form.Group>
-
-                        <Form.Group className="my-3" controlId="formBasicConfirmPassword">
-                            <Form.Label>Confirm Password *</Form.Label>
-                            <Form.Control type="password" placeholder="Confirm Password" name='confirmPassword' value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
-                        </Form.Group>
-
-                    </Form>
-                </Modal.Body>
-                <Modal.Footer onSubmit={handleEditProfile}>
-                    <button type="button" className="btn btn-secondary" onClick={handleClosePassword}>Close</button>
-                    <button type="button" className="btn btn-primary" onClick={handleSavePassword}>Save changes</button>
-                </Modal.Footer>
-            </Modal>
+            <ModalPassword username={infoProfile.username} show={showPasswordEdit} handleClose={handleClosePassword} />
         </>
     );
 };

--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -52,6 +52,10 @@ const getState = ({ getStore, getActions, setStore }) => {
 				return null
 			},
 
+			checkPassword: async (data) => {
+				return await getActions().APICall('check-password/', await getActions().optionsMethod('POST', data))
+			},
+
 			signup: async (data) => {
 				const response = await getActions().APICall('signup/', await getActions().optionsMethod('POST', data));
 				if (typeof response == 'object') {


### PR DESCRIPTION
## Changelog

### Nuevos Componentes
- **ModalPassword**: Este componente fue creado desde cero. Se encarga de mostrar un modal que permite al usuario cambiar su contraseña. Incluye la lógica para manejar el estado de la contraseña y la confirmación de la contraseña, así como la lógica para manejar la apertura y el cierre del modal.

- **ModalConfirmPassword**: Este componente también fue creado desde cero. Se muestra cuando el usuario intenta guardar los cambios en `ModalPassword` pero la contraseña actual no es correcta. Este modal solicita al usuario que confirme su contraseña actual antes de permitirle cambiarla.

### Cambios en los Componentes Existentes

- **Profile.jsx**: Se añadió la lógica para manejar la apertura y el cierre del componente `Settings`. También se añadió la lógica para obtener el perfil del usuario.

- **Settings.jsx**: Se añadió la lógica para manejar la apertura y el cierre del componente `ModalPassword`. También se añadió la lógica para manejar la edición del perfil del usuario.

### Cambios en la Lógica

- Se añadió la lógica para verificar si la contraseña actual del usuario es correcta antes de permitirle cambiarla. Si la contraseña actual no es correcta, se muestra el modal de confirmación de contraseña.

- Se añadió la lógica para manejar la confirmación de la contraseña. Si la contraseña es confirmada correctamente, se permite al usuario cambiarla.

### Nuevos Endpoints

- **/check-password (POST)**: Este endpoint fue creado desde cero. Se encarga de verificar si la contraseña proporcionada por el usuario es correcta. Si la contraseña es correcta, devuelve un mensaje de éxito y un resultado de `true`. Si la contraseña es incorrecta, devuelve un mensaje de error y un resultado de `false`.

### Nuevas Funciones en Flux.js

- **checkPassword**: Esta función fue añadida a `flux.js`. Esta función realiza una llamada API al endpoint `/check-password` con el método `POST`. La función toma un objeto `data` como argumento, que contiene la contraseña que se va a verificar.